### PR TITLE
Fix JEI crash when Create categories missing

### DIFF
--- a/src/main/java/someassemblyrequired/integration/jei/JEIPlugin.java
+++ b/src/main/java/someassemblyrequired/integration/jei/JEIPlugin.java
@@ -76,7 +76,10 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerAdvanced(IAdvancedRegistration registration) {
         if (ModCompat.isCreateLoaded()) {
-            SequencedAssemblyRecipeGenerator.register(registration);
+            // Only register sequenced assembly integration when the recipe type is available
+            registration.getJeiHelpers()
+                    .getRecipeType(ResourceLocation.parse(ModCompat.CREATE + ":sequenced_assembly"))
+                    .ifPresent(type -> SequencedAssemblyRecipeGenerator.register(registration));
         }
         registration.addTypedRecipeManagerPlugin(SANDWICHING_STATION, new SandwichingStationRecipeGenerator());
     }


### PR DESCRIPTION
## Summary
- check for Create's sequenced assembly recipe type before registering

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6871f38be22c83328cc54fdb8460f903