### PR TITLE
Fix JEI crash when Create category missing

### DIFF
--- a/src/main/java/someassemblyrequired/integration/jei/JEIPlugin.java
+++ b/src/main/java/someassemblyrequired/integration/jei/JEIPlugin.java
@@ -19,6 +19,8 @@ import someassemblyrequired.item.sandwich.SandwichContents;
 import someassemblyrequired.registry.ModBlocks;
 import someassemblyrequired.registry.ModItems;
 
+import mezz.jei.api.runtime.IJeiRuntime;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -27,6 +29,7 @@ import java.util.List;
 public class JEIPlugin implements IModPlugin {
 
     private static final ResourceLocation ID = SomeAssemblyRequired.id("main");
+    private static boolean hasSequencedAssemblyCategory = false;
 
     public static final RecipeType<SandwichingStationCategory.Recipe> SANDWICHING_STATION = RecipeType.create(SomeAssemblyRequired.MOD_ID, "sandwiching_station", SandwichingStationCategory.Recipe.class);
 
@@ -76,7 +79,10 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerAdvanced(IAdvancedRegistration registration) {
         if (ModCompat.isCreateLoaded()) {
-            SequencedAssemblyRecipeGenerator.register(registration);
+            // Only register sequenced assembly integration when the recipe type is available
+            registration.getJeiHelpers()
+                    .getRecipeType(ResourceLocation.parse(ModCompat.CREATE + ":sequenced_assembly"))
+                    .ifPresent(type -> SequencedAssemblyRecipeGenerator.register(registration));
         }
         registration.addTypedRecipeManagerPlugin(SANDWICHING_STATION, new SandwichingStationRecipeGenerator());
     }
@@ -114,5 +120,21 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.SANDWICHING_STATION.get()), SANDWICHING_STATION);
+    }
+
+    @Override
+    public void onRuntimeAvailable(IJeiRuntime runtime) {
+        if (ModCompat.isCreateLoaded()) {
+            hasSequencedAssemblyCategory = runtime.getRecipeManager()
+                    .createRecipeCategoryLookup()
+                    .limitTypes(List.of(SequencedAssemblyRecipeGenerator.SEQUENCED_ASSEMBLY))
+                    .get()
+                    .findAny()
+                    .isPresent();
+        }
+    }
+
+    public static boolean hasSequencedAssemblyCategory() {
+        return hasSequencedAssemblyCategory;
     }
 }

--- a/src/main/java/someassemblyrequired/integration/jei/create/SequencedAssemblyRecipeGenerator.java
+++ b/src/main/java/someassemblyrequired/integration/jei/create/SequencedAssemblyRecipeGenerator.java
@@ -21,6 +21,8 @@ import someassemblyrequired.SomeAssemblyRequired;
 import someassemblyrequired.integration.ModCompat;
 import someassemblyrequired.integration.create.recipe.SandwichFluidSpoutingRecipe;
 import someassemblyrequired.integration.jei.SandwichRecipeGenerator;
+import someassemblyrequired.integration.jei.JEIPlugin;
+import mezz.jei.api.ingredients.ITypedIngredient;
 import someassemblyrequired.item.sandwich.SandwichContents;
 import someassemblyrequired.item.sandwich.SandwichItem;
 import someassemblyrequired.recipe.SandwichSpoutingRecipe;
@@ -33,7 +35,7 @@ import java.util.stream.Stream;
 
 public class SequencedAssemblyRecipeGenerator extends SandwichRecipeGenerator<SequencedAssemblyRecipe> {
 
-    private static final RecipeType<SequencedAssemblyRecipe> SEQUENCED_ASSEMBLY = RecipeType.create(ModCompat.CREATE, "sequenced_assembly", SequencedAssemblyRecipe.class);
+    public static final RecipeType<SequencedAssemblyRecipe> SEQUENCED_ASSEMBLY = RecipeType.create(ModCompat.CREATE, "sequenced_assembly", SequencedAssemblyRecipe.class);
 
     public static void register(IAdvancedRegistration registration) {
         registration.addTypedRecipeManagerPlugin(SEQUENCED_ASSEMBLY, new SequencedAssemblyRecipeGenerator());
@@ -42,6 +44,31 @@ public class SequencedAssemblyRecipeGenerator extends SandwichRecipeGenerator<Se
     @Override
     protected int getMaxToppings() {
         return 6;
+    }
+
+    @Override
+    public boolean isHandledInput(ITypedIngredient<?> input) {
+        return JEIPlugin.hasSequencedAssemblyCategory() && super.isHandledInput(input);
+    }
+
+    @Override
+    public boolean isHandledOutput(ITypedIngredient<?> output) {
+        return JEIPlugin.hasSequencedAssemblyCategory() && super.isHandledOutput(output);
+    }
+
+    @Override
+    public List<SequencedAssemblyRecipe> getRecipesForInput(ITypedIngredient<?> input) {
+        return JEIPlugin.hasSequencedAssemblyCategory() ? super.getRecipesForInput(input) : List.of();
+    }
+
+    @Override
+    public List<SequencedAssemblyRecipe> getRecipesForOutput(ITypedIngredient<?> output) {
+        return JEIPlugin.hasSequencedAssemblyCategory() ? super.getRecipesForOutput(output) : List.of();
+    }
+
+    @Override
+    public List<SequencedAssemblyRecipe> getAllRecipes() {
+        return JEIPlugin.hasSequencedAssemblyCategory() ? super.getAllRecipes() : List.of();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- check JEI runtime for `sequenced_assembly` category
- skip sequenced assembly recipes when category is absent

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6871f38be22c83328cc54fdb8460f903