### PR TITLE
Sync crash prevention from upstream PRs

### DIFF
--- a/src/main/java/someassemblyrequired/integration/jei/JEIPlugin.java
+++ b/src/main/java/someassemblyrequired/integration/jei/JEIPlugin.java
@@ -15,6 +15,8 @@ import someassemblyrequired.item.sandwich.SandwichItemHandler;
 import someassemblyrequired.registry.ModBlocks;
 import someassemblyrequired.registry.ModItems;
 
+import mezz.jei.api.runtime.IJeiRuntime;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -23,6 +25,7 @@ import java.util.List;
 public class JEIPlugin implements IModPlugin {
 
     private static final ResourceLocation ID = SomeAssemblyRequired.id("main");
+    private static boolean hasSequencedAssemblyCategory = false;
 
     public static final RecipeType<SandwichingStationCategory.Recipe> SANDWICHING_STATION = RecipeType.create(SomeAssemblyRequired.MOD_ID, "sandwiching_station", SandwichingStationCategory.Recipe.class);
 
@@ -43,7 +46,10 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerAdvanced(IAdvancedRegistration registration) {
         if (ModCompat.isCreateLoaded()) {
-            SequencedAssemblyRecipeGenerator.register(registration);
+            // Only register sequenced assembly integration when the recipe type is available
+            registration.getJeiHelpers()
+                    .getRecipeType(ResourceLocation.parse(ModCompat.CREATE + ":sequenced_assembly"))
+                    .ifPresent(type -> SequencedAssemblyRecipeGenerator.register(registration));
         }
         registration.addTypedRecipeManagerPlugin(SANDWICHING_STATION, new SandwichingStationRecipeGenerator());
     }
@@ -80,5 +86,20 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerRecipeCatalysts(IRecipeCatalystRegistration registration) {
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.SANDWICHING_STATION.get()), SANDWICHING_STATION);
+    }
+    @Override
+    public void onRuntimeAvailable(IJeiRuntime runtime) {
+        if (ModCompat.isCreateLoaded()) {
+            hasSequencedAssemblyCategory = runtime.getRecipeManager()
+                    .createRecipeCategoryLookup()
+                    .limitTypes(List.of(SequencedAssemblyRecipeGenerator.SEQUENCED_ASSEMBLY))
+                    .get()
+                    .findAny()
+                    .isPresent();
+        }
+    }
+
+    public static boolean hasSequencedAssemblyCategory() {
+        return hasSequencedAssemblyCategory;
     }
 }

--- a/src/main/java/someassemblyrequired/integration/jei/create/SequencedAssemblyRecipeGenerator.java
+++ b/src/main/java/someassemblyrequired/integration/jei/create/SequencedAssemblyRecipeGenerator.java
@@ -21,6 +21,9 @@ import someassemblyrequired.SomeAssemblyRequired;
 import someassemblyrequired.integration.ModCompat;
 import someassemblyrequired.integration.create.recipe.SandwichFluidSpoutingRecipe;
 import someassemblyrequired.integration.jei.SandwichRecipeGenerator;
+import someassemblyrequired.integration.jei.JEIPlugin;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import someassemblyrequired.item.sandwich.SandwichContents;
 import someassemblyrequired.item.sandwich.SandwichItem;
 import someassemblyrequired.item.sandwich.SandwichItemHandler;
 import someassemblyrequired.recipe.SandwichSpoutingRecipe;
@@ -33,7 +36,7 @@ import java.util.stream.Stream;
 
 public class SequencedAssemblyRecipeGenerator extends SandwichRecipeGenerator<SequencedAssemblyRecipe> {
 
-    private static final RecipeType<SequencedAssemblyRecipe> SEQUENCED_ASSEMBLY = RecipeType.create(ModCompat.CREATE, "sequenced_assembly", SequencedAssemblyRecipe.class);
+    public static final RecipeType<SequencedAssemblyRecipe> SEQUENCED_ASSEMBLY = RecipeType.create(ModCompat.CREATE, "sequenced_assembly", SequencedAssemblyRecipe.class);
 
     public static void register(IAdvancedRegistration registration) {
         registration.addTypedRecipeManagerPlugin(SEQUENCED_ASSEMBLY, new SequencedAssemblyRecipeGenerator());
@@ -42,6 +45,31 @@ public class SequencedAssemblyRecipeGenerator extends SandwichRecipeGenerator<Se
     @Override
     protected int getMaxToppings() {
         return 6;
+    }
+
+    @Override
+    public boolean isHandledInput(ITypedIngredient<?> input) {
+        return JEIPlugin.hasSequencedAssemblyCategory() && super.isHandledInput(input);
+    }
+
+    @Override
+    public boolean isHandledOutput(ITypedIngredient<?> output) {
+        return JEIPlugin.hasSequencedAssemblyCategory() && super.isHandledOutput(output);
+    }
+
+    @Override
+    public List<SequencedAssemblyRecipe> getRecipesForInput(ITypedIngredient<?> input) {
+        return JEIPlugin.hasSequencedAssemblyCategory() ? super.getRecipesForInput(input) : List.of();
+    }
+
+    @Override
+    public List<SequencedAssemblyRecipe> getRecipesForOutput(ITypedIngredient<?> output) {
+        return JEIPlugin.hasSequencedAssemblyCategory() ? super.getRecipesForOutput(output) : List.of();
+    }
+
+    @Override
+    public List<SequencedAssemblyRecipe> getAllRecipes() {
+        return JEIPlugin.hasSequencedAssemblyCategory() ? super.getAllRecipes() : List.of();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- avoid crash if Create JEI category is missing
- handle missing Create JEI category

## Testing
- `./gradlew tasks --all` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6878e25caa588332a60eb5fce19f2043